### PR TITLE
Update docker-compose services

### DIFF
--- a/config/datasource.yml
+++ b/config/datasource.yml
@@ -25,7 +25,7 @@ datasources:
   type: tempo
   uid: tempo
   access: proxy
-  url: http://tempo-query:16686
+  url: http://tempo:80
   isDefault: false
   version: 1
   editable: false
@@ -40,7 +40,7 @@ datasources:
   editable: false
   basicAuth: false
   jsonData:
-    httpMethod: 'GET'
-    exemplarTraceIDDestination:
-      name: 'traceID'
-      url: 'http://localhost:3000/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22tempo%22,%7B%22query%22:%22$${value}%22%7D%5D'
+    httpMethod: POST
+    exemplarTraceIdDestinations:
+      - datasourceUid: tempo
+        name: traceID

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
         loki-url: http://localhost:3100/loki/api/v1/push
 
   tempo:
-    image: grafana/tempo:0.5.0
+    image: grafana/tempo:1.0.1
     command: ["--target=all", "--storage.trace.backend=local", "--storage.trace.local.path=/var/tempo", "--auth.enabled=false"]
     ports:
     - 8081:80
@@ -19,23 +19,8 @@ services:
       options:
         loki-url: 'http://localhost:3100/api/prom/push'
 
-  tempo-query:
-    image: grafana/tempo-query:latest
-    environment:
-    - BACKEND=tempo:80
-    volumes:
-    - ./etc/tempo-query.yaml:/etc/tempo-query.yaml
-    ports:
-    - "16686:16686"  # jaeger-ui
-    depends_on:
-    - tempo
-    logging:
-      driver: loki
-      options:
-        loki-url: 'http://localhost:3100/api/prom/push'
-
   grafana:
-    image: grafana/grafana:7.3.x-exemplars
+    image: grafana/grafana:8.0.6
     volumes:
     - ./config/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml
     environment:
@@ -46,7 +31,7 @@ services:
     - "3000:3000"
 
   loki:
-    image: grafana/loki:2.1.0
+    image: grafana/loki:2.2.1
     command: -config.file=/etc/loki/local-config.yaml
     ports:
     - "3100:3100"
@@ -56,11 +41,12 @@ services:
         loki-url: 'http://localhost:3100/api/prom/push'
 
   prometheus:
-    image: cstyan/prometheus:exemplars-64206a
+    image: prom/prometheus:v2.28.1
     volumes:
       - ./config/prometheus.yaml:/etc/prometheus.yaml
     entrypoint:
       - /bin/prometheus
       - --config.file=/etc/prometheus.yaml
+      - --enable-feature=exemplar-storage
     ports:
       - "9090:9090"


### PR DESCRIPTION
Thanks for your excellent youtube video about Loki+Tempo+Prometheus+exemplars!

I was curious if this example would work on the newest versions of Prometheus and Tempo. I've updated the versions and found that the PR's you mentioned were merged in Prometheus. The exemplars storage is still experimental, but that can be enabled with a flag.